### PR TITLE
Add labels parameter to gemini.vertex function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gemini.R
 Title: Interface for 'Google Gemini' API
-Version: 0.16.1
+Version: 0.16.2
 Authors@R: c(
   person("Jinhwan", "Kim", , "hwanistic@gmail.com", role = c("aut", "cre", "cph"), comment = c(ORCID = "0009-0009-3217-2417")),
   person("Maciej", "Nasinski", role = "ctb"))

--- a/man/gemini.vertex.Rd
+++ b/man/gemini.vertex.Rd
@@ -12,7 +12,8 @@ gemini.vertex(
   topK = 40,
   topP = 0.95,
   seed = 1234,
-  timeout = 60
+  timeout = 60,
+  labels = NULL
 )
 }
 \arguments{
@@ -36,6 +37,9 @@ see https://ai.google.dev/gemini-api/docs/models/generative-models#model-paramet
 see https://ai.google.dev/gemini-api/docs/models/generative-models#model-parameters}
 
 \item{timeout}{Request timeout in seconds. Default is 60.}
+
+\item{labels}{(Optional) A named list for custom metadata labels.
+Example: \code{list(team = "research", env = "test")}.}
 }
 \value{
 A character string containing the generated text.
@@ -48,6 +52,7 @@ Generate text from text with Gemini Vertex API
 # token should be created before this. using the token.vertex() function
 prompt <- "What is sachins Jersey number?"
 gemini.vertex(prompt, tokens)
+gemini.vertex(prompt, tokens, labels = list(team = "research", env = "test"))
 }
 
 }


### PR DESCRIPTION
Introduces an optional 'labels' parameter to gemini.vertex, allowing users to pass custom metadata as a named list. Updates documentation and parameter validation to support this feature.