### PR TITLE
feat: add timeout to gemini_image;

### DIFF
--- a/R/gemini_image.R
+++ b/R/gemini_image.R
@@ -15,6 +15,7 @@
 #' @param seed The seed to use. Default is 1234 value should be integer
 #'              see https://ai.google.dev/gemini-api/docs/models/generative-models#model-parameters
 #' @param type The type of image. Options are 'png', 'jpeg', 'webp', 'heic', 'heif'. Default is 'png'
+#' @param timeout Request timeout in seconds. Default is 60.
 #'
 #' @return Generated text
 #' @export
@@ -25,7 +26,7 @@
 #' gemini_image(image = system.file("docs/reference/figures/image.png", package = "gemini.R"))
 #' }
 #'
-#' @importFrom httr2 request req_headers req_body_json req_perform resp_body_json
+#' @importFrom httr2 request req_headers req_body_json req_perform resp_body_json req_timeout
 #' @importFrom base64enc base64encode
 #' @importFrom cli cli_alert_danger cli_status_clear cli_status
 #'
@@ -37,7 +38,7 @@
 
 gemini_image <- function(image = NULL, prompt = "Explain this image", model = "2.0-flash",
                          temperature = 1, maxOutputTokens = 8192, topK = 40, topP = 0.95,
-                         seed = 1234, type = "png") {
+                         seed = 1234, type = "png", timeout = 60) {
   # 1. validate_params 함수 사용
   if (!validate_params(prompt, model, temperature, topP, topK, seed, api_key = TRUE)) {
     return(NULL)
@@ -112,6 +113,7 @@ gemini_image <- function(image = NULL, prompt = "Explain this image", model = "2
   )
 
   req <- request(url) |>
+    req_timeout(as.integer(timeout)) |>
     req_headers(
       "Content-Type" = "application/json",
       "x-goog-api-key" = api_key
@@ -152,16 +154,17 @@ gemini_image <- function(image = NULL, prompt = "Explain this image", model = "2
 #'              see https://ai.google.dev/gemini-api/docs/models/generative-models#model-parameters
 #' @param seed The seed to use. Default is 1234 value should be integer
 #'              see https://ai.google.dev/gemini-api/docs/models/generative-models#model-parameters
+#' @param timeout Request timeout in seconds. Default is 60.
 #'
 #' @return A character vector containing Gemini's description of the image.
 #'
 #' @importFrom cli cli_alert_danger cli_status cli_status_clear
-#' @importFrom httr2 request req_headers req_body_json req_perform resp_body_json
+#' @importFrom httr2 request req_headers req_body_json req_perform resp_body_json req_timeout
 #' @importFrom base64enc base64encode
 #'
 #' @export
 gemini_image.vertex <- function(image = NULL, prompt = "Explain this image", type = "png", tokens = NULL,
-                                temperature = 1, maxOutputTokens = 8192, topK = 40, topP = 0.95, seed = 1234) {
+                                temperature = 1, maxOutputTokens = 8192, topK = 40, topP = 0.95, seed = 1234, timeout = 60) {
   # 1. Use validate_params function
   if (!validate_params(prompt, NULL, temperature, topP, topK, seed, api_key = FALSE, tokens = tokens)) {
     return(NULL)
@@ -237,6 +240,7 @@ gemini_image.vertex <- function(image = NULL, prompt = "Explain this image", typ
 
   # Separate API request for status code validation
   req <- request(tokens$url) |>
+    req_timeout(as.integer(timeout)) |>
     req_headers(
       "Authorization" = paste0("Bearer ", tokens$key),
       "Content-Type" = "application/json"

--- a/man/gemini_image.Rd
+++ b/man/gemini_image.Rd
@@ -13,7 +13,8 @@ gemini_image(
   topK = 40,
   topP = 0.95,
   seed = 1234,
-  type = "png"
+  type = "png",
+  timeout = 60
 )
 }
 \arguments{
@@ -40,6 +41,8 @@ see https://ai.google.dev/gemini-api/docs/models/generative-models#model-paramet
 see https://ai.google.dev/gemini-api/docs/models/generative-models#model-parameters}
 
 \item{type}{The type of image. Options are 'png', 'jpeg', 'webp', 'heic', 'heif'. Default is 'png'}
+
+\item{timeout}{Request timeout in seconds. Default is 60.}
 }
 \value{
 Generated text

--- a/man/gemini_image.vertex.Rd
+++ b/man/gemini_image.vertex.Rd
@@ -13,7 +13,8 @@ gemini_image.vertex(
   maxOutputTokens = 8192,
   topK = 40,
   topP = 0.95,
-  seed = 1234
+  seed = 1234,
+  timeout = 60
 )
 }
 \arguments{
@@ -39,6 +40,8 @@ see https://ai.google.dev/gemini-api/docs/models/generative-models#model-paramet
 
 \item{seed}{The seed to use. Default is 1234 value should be integer
 see https://ai.google.dev/gemini-api/docs/models/generative-models#model-parameters}
+
+\item{timeout}{Request timeout in seconds. Default is 60.}
 }
 \value{
 A character vector containing Gemini's description of the image.


### PR DESCRIPTION
This pull request adds support for specifying a request timeout in the `gemini_image` and `gemini_image.vertex` functions, improving robustness for slow or unreliable network conditions. The timeout parameter is now documented and implemented in both the R code and the associated documentation.

**New timeout parameter support:**

* Added a `timeout` parameter (default 60 seconds) to both `gemini_image` and `gemini_image.vertex` functions, allowing users to control the maximum duration for API requests. [[1]](diffhunk://#diff-aab8a9f0d182ac84275a450bb48320772e3d34568da1e50758100603b5bc09f9R18) [[2]](diffhunk://#diff-aab8a9f0d182ac84275a450bb48320772e3d34568da1e50758100603b5bc09f9L40-R41) [[3]](diffhunk://#diff-aab8a9f0d182ac84275a450bb48320772e3d34568da1e50758100603b5bc09f9R157-R167)
* Updated API requests in both functions to use the specified timeout by incorporating the `req_timeout` function from `httr2`. [[1]](diffhunk://#diff-aab8a9f0d182ac84275a450bb48320772e3d34568da1e50758100603b5bc09f9R116) [[2]](diffhunk://#diff-aab8a9f0d182ac84275a450bb48320772e3d34568da1e50758100603b5bc09f9R243)

**Documentation updates:**

* Updated Roxygen comments and `.Rd` documentation files to include the new `timeout` parameter and its default value. [[1]](diffhunk://#diff-ee6d053f64cce6de1cad20bde1907d543ec4772cf6cabeacd3f9a9f37ad4cb6dL16-R17) [[2]](diffhunk://#diff-ee6d053f64cce6de1cad20bde1907d543ec4772cf6cabeacd3f9a9f37ad4cb6dR44-R45) [[3]](diffhunk://#diff-76553075d73848d2d1eff7a53c7f2376ff6c95c372e0919647539dcfe370aea4L16-R17) [[4]](diffhunk://#diff-76553075d73848d2d1eff7a53c7f2376ff6c95c372e0919647539dcfe370aea4R43-R44)
* Added `req_timeout` to the list of imported functions from `httr2` in both functions. [[1]](diffhunk://#diff-aab8a9f0d182ac84275a450bb48320772e3d34568da1e50758100603b5bc09f9L28-R29) [[2]](diffhunk://#diff-aab8a9f0d182ac84275a450bb48320772e3d34568da1e50758100603b5bc09f9R157-R167)close #69